### PR TITLE
Change barcodeScanner and relayControl to be POST requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ venv.bak/
 
 .vscode
 decaf/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -46,19 +46,22 @@ dbhost = '************'
  
  dont forget to change the ip to your Pi's IP, or local host if your are browsing from the pi itself.
 
-#### Relay control formatting:
+#### Relay control formatting
 
-It currently requires 6 arguments:
-* pinNumber
-* relayChannel
-* timeOn
-* repeatValue
-* repeatDelay
-* connectedHardware
+It currently requires 5 arguments:
+* `pin` (int) GPIO Pin Number
+* `channel` (int) Relay Channel
+* `timeOn` (float) Total running time
+* `repeat` (int) Number of times to repeat
+* `repeatDelay` (float) Delay between repeat times
 
 Example:
-http://192.168.1.183:5000/relayControl/23/1/2/2/4/grinder
+```
+POST http://192.168.1.183:5000/relayControl/grinder HTTP/1.1
+Content-Type: application/json
 
+{"pin":"23","channel":"1","timeOn":"1.0","repeat":"3","repeatDelay":"2.0"}
+```
 This turns on pin 23 which is connected to relay channel 1 for 2 seconds, it repeats 2 times with a delay of 4 seconds between repeats and is connected to the grinder.
 
 #### Get Pin Info By Hardware Type:
@@ -66,7 +69,7 @@ Access pinInfo by pointing your browser or a curl request to:
 http://192.168.1.183:5000/pinInfo/grinder
 
 
- ### Please note that this runs decaf on the Flask development server and is not meant for production!
+### Please note that this runs decaf on the Flask development server and is not meant for production!
 
 ## Run on Docker on Raspbian
 
@@ -75,4 +78,3 @@ http://192.168.1.183:5000/pinInfo/grinder
 3. Edit config file as above. `dbhost = 'localhost'`, `dbuser = 'root'`, `dbpass = ''`, `dbdb = 'mugsy'`
 4. `docker build -t heymugsy .`
 5. `docker run -it --rm -p 5000:5000 -v /var/lib/mysql heymugsy`
-

--- a/models.py
+++ b/models.py
@@ -79,14 +79,16 @@ class RelayControl:
 			GPIO.output(pinNumber, GPIO.HIGH)
 		GPIO.cleanup()
 		
-		return {'relayController' : [
-			pinNumber, 
-			relayChannel, 
-			timeOn, 
-			repeatValue, 
-			repeatDelay, 
-			connectedHardware,
-		]}
+		response = {
+			'pinNumber': pinNumber, 
+			'relayChannel': relayChannel, 
+			'timeOn': timeOn, 
+			'repeatValue': repeatValue, 
+			'repeatDelay': repeatDelay, 
+			'connectedHardware': connectedHardware,
+		}
+
+		return {'relayController' : response}
 
 
 

--- a/models.py
+++ b/models.py
@@ -59,33 +59,33 @@ class PinMappings:
 
 class RelayControl:
 	@staticmethod
-	def get(pinNumber, relayChannel, timeOn, repeatValue, repeatDelay, connectedHardware):
-		GPIO.setmode(GPIO.BCM)
-		pinNumber = int(pinNumber)
+	def get(pin, channel, timeOn, repeat, repeatDelay, hardware):
+		pin = int(pin)
 		timeOn = float(timeOn)
-		repeatValue = int(repeatValue)
-		repeatDelay = int(repeatDelay)
+		repeat = int(repeat)
+		repeatDelay = float(repeatDelay)
 
-		GPIO.setup(pinNumber, GPIO.OUT)
-		if (repeatValue > 1):
-			for _ in itertools.repeat(None, repeatValue):
-				GPIO.output(pinNumber, GPIO.LOW)
+		GPIO.setmode(GPIO.BCM)
+		GPIO.setup(pin, GPIO.OUT)
+		if (repeat > 1):
+			for _ in itertools.repeat(None, repeat):
+				GPIO.output(pin, GPIO.LOW)
 				time.sleep(timeOn)
-				GPIO.output(pinNumber, GPIO.HIGH)
+				GPIO.output(pin, GPIO.HIGH)
 				time.sleep(repeatDelay)
 		else:
-			GPIO.output(pinNumber, GPIO.LOW)
+			GPIO.output(pin, GPIO.LOW)
 			time.sleep(timeOn)
-			GPIO.output(pinNumber, GPIO.HIGH)
+			GPIO.output(pin, GPIO.HIGH)
 		GPIO.cleanup()
 		
 		response = {
-			'pinNumber': pinNumber, 
-			'relayChannel': relayChannel, 
+			'pin': pin, 
+			'channel': channel, 
 			'timeOn': timeOn, 
-			'repeatValue': repeatValue, 
+			'repeat': repeat, 
 			'repeatDelay': repeatDelay, 
-			'connectedHardware': connectedHardware,
+			'hardware': hardware,
 		}
 
 		return {'relayController' : response}


### PR DESCRIPTION
Updates methods that trigger some sort of action (scan barcode, set relay control) to be POST requests.

Relay control now takes a JSON payload that describes the argument names. The return response is now a dictionary, instead of a unclear list of values.